### PR TITLE
Use concrete types in type aliases for Point, Dimensions, and Margins

### DIFF
--- a/examples/Boxes.elm
+++ b/examples/Boxes.elm
@@ -8,8 +8,8 @@ margin = { top = 10, left = 10, right = 10, bottom = 10 }
 dims   = { height = size - margin.top - margin.bottom
          , width  = size - margin.left - margin.right }
 
-type Dimensions = { height : number, width : number }
-type Margins = { top : number, left : number, right : number, bottom : number }
+type Dimensions = { height : Float, width : Float }
+type Margins = { top : Float, left : Float, right : Float, bottom : Float }
 
 svg : Dimensions -> Margins -> Selection a
 svg ds ms =

--- a/examples/Circles.elm
+++ b/examples/Circles.elm
@@ -9,8 +9,8 @@ margin = { top = 25, left = 25, right = 25, bottom = 25 }
 dims   = { height = size - margin.top - margin.bottom
          , width  = size - margin.left - margin.right }
 
-type Dimensions = { height : number, width : number }
-type Margins = { top : number, left : number, right : number, bottom : number }
+type Dimensions = { height : Int, width : Int }
+type Margins = { top : Int, left : Int, right : Int, bottom : Int }
 
 svg : Dimensions -> Margins -> Selection a
 svg ds ms =

--- a/examples/Voronoi.elm
+++ b/examples/Voronoi.elm
@@ -12,8 +12,8 @@ margin = { top = 0, left = 0, right = 0, bottom = 0 }
 dims   = { height = height - margin.top - margin.bottom
          , width  = width - margin.left - margin.right }
 
-type Dimensions = { height : number, width : number }
-type Margins = { top : number, left : number, right : number, bottom : number }
+type Dimensions = { height : Float, width : Float }
+type Margins = { top : Float, left : Float, right : Float, bottom : Float }
 
 svg : Dimensions -> Margins -> Selection a
 svg ds ms =

--- a/src/D3/Voronoi.elm
+++ b/src/D3/Voronoi.elm
@@ -6,10 +6,10 @@ module D3.Voronoi
 import Native.D3.Voronoi
 import String
 
-type Point = { x : number, y : number }
+type Point = { x : Float, y : Float }
 
 cells : [Point] -> [[Point]]
 cells = Native.D3.Voronoi.cells
 
-cellsWithClipping : number -> number -> number -> number -> [Point] -> [[Point]]
+cellsWithClipping : Float -> Float -> Float -> Float -> [Point] -> [[Point]]
 cellsWithClipping = Native.D3.Voronoi.cellsWithClipping


### PR DESCRIPTION
As described in issue #2.
