### PR TITLE
Bug fix: Event returns Selection module

### DIFF
--- a/src/Native/D3/Event.js
+++ b/src/Native/D3/Event.js
@@ -8,7 +8,7 @@ Elm.Native.D3.Event.make = function(elm) {
   elm.Native.D3 = elm.Native.D3 || {};
   elm.Native.D3.Event = elm.Native.D3.Event || {};
 
-  if (elm.Native.D3.Selection.values) return elm.Native.D3.Selection.values;
+  if (elm.Native.D3.Event.values) return elm.Native.D3.Event.values;
 
   var JS = Elm.Native.D3.JavaScript.make(elm);
 


### PR DESCRIPTION
Will cause things to go wrong if someone initializes the Event module after Selection has already been initialized.
