### PR TITLE
1 line change to enable D3/Event.elm to compile

### DIFF
--- a/src/D3.elm
+++ b/src/D3.elm
@@ -27,6 +27,7 @@ module D3
   , transition              -- : Selection a
   , delay                   -- : (a -> Int -> Int) -> Selection a
   , duration                -- : (a -> Int -> Int) -> Selection a
+  , Selection
   ) where
 
 import Json(..)


### PR DESCRIPTION
In Elm 0.13,  I found that src/D3/Event.elm was not getting the Selection type from src/D3.  This 1 line change addresses that. 
